### PR TITLE
Update Aesni.c

### DIFF
--- a/UefiCpuPkg/Library/CpuCommonFeaturesLib/Aesni.c
+++ b/UefiCpuPkg/Library/CpuCommonFeaturesLib/Aesni.c
@@ -123,7 +123,7 @@ AesniInitialize (
         MSR_SANDY_BRIDGE_FEATURE_CONFIG,
         MSR_SANDY_BRIDGE_FEATURE_CONFIG_REGISTER,
         Bits.AESConfiguration,
-        BIT1 | ((State) ? 0 : BIT0)
+        BIT0 | ((State) ? 0 : BIT1)
         );
     }
   }


### PR DESCRIPTION
Need to fix bit order !
Intel's MSR spec ( Table 2.6, Vol. 4, 2-73, Page 89/472 ) says Bit 0 is to lock feature and Bit 1 to disable/enable AES-NI as you can see here:

[https://software.intel.com/en-us/download/intel-64-and-ia-32-architectures-software-developers-manual-volume-4-model-specific-registers](https://software.intel.com/en-us/download/intel-64-and-ia-32-architectures-software-developers-manual-volume-4-model-specific-registers)

So, the bits must be swapped to be ok in your code.

The code was corrected time ago in the tianocore/edk2 original repo as you can see here:
[https://bugzilla.tianocore.org/show_bug.cgi?id=1621](https://bugzilla.tianocore.org/show_bug.cgi?id=1621)