### PR TITLE
Fix Network stack not being loaded

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -855,6 +855,18 @@
   }
 !endif
 
+  #
+  # Rng Protocol producer
+  #
+  SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.inf
+
+  #
+  # Hash2 Protocol producer
+  #
+  SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
+
+
+
 !if $(SECURE_BOOT_ENABLE) == TRUE
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
   UefiPayloadPkg/SecureBootEnrollDefaultKeys/SecureBootSetup.inf

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -855,6 +855,7 @@
   }
 !endif
 
+!if $(NETWORK_DRIVER_ENABLE) == TRUE
   #
   # Rng Protocol producer
   #
@@ -864,7 +865,7 @@
   # Hash2 Protocol producer
   #
   SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
-
+!endif
 
 
 !if $(SECURE_BOOT_ENABLE) == TRUE

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -389,6 +389,15 @@ INF MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
 #
 !if $(NETWORK_DRIVER_ENABLE) == TRUE
   !include NetworkPkg/Network.fdf.inc
+  #
+  # Rng Protocol producer
+  #
+  INF  SecurityPkg/RandomNumberGenerator/RngDxe/RngDxe.inf
+  
+  #
+  # Hash2 Protocol producer
+  #
+  INF  SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
 !endif
 !endif
 


### PR DESCRIPTION
# Description
Due to the changes in the commit  4c4ceb2c, the Network Stack requires the use of a new Random Number Generator (RNG). The UefiPayloadPkg has not been patched on default EDK2, since network implementation is not default in it. Therefore, the solution was to apply something that was done in another platforms in EDK2 adding the RngDxe and the Hash2DxeCrypto drivers (commits 3e722403 and e10d8323).

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The Loading of the network stack was done in an proprietary device in development

## Integration Instructions

N/A
