### PR TITLE
UnitTestFrameworkPkg: Use TianoCore mirror of subhook submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 	url = https://github.com/google/googletest.git
 [submodule "UnitTestFrameworkPkg/Library/SubhookLib/subhook"]
 	path = UnitTestFrameworkPkg/Library/SubhookLib/subhook
-	url = https://github.com/Zeex/subhook.git
+	url = https://github.com/tianocore/edk2-subhook.git
 [submodule "MdePkg/Library/BaseFdtLib/libfdt"]
 	path = MdePkg/Library/BaseFdtLib/libfdt
 	url = https://github.com/devicetree-org/pylibfdt.git

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -96,7 +96,7 @@ that are covered by additional licenses.
 -  `MdeModulePkg/Universal/RegularExpressionDxe/oniguruma <https://github.com/kkos/oniguruma/blob/abfc8ff81df4067f309032467785e06975678f0d/COPYING>`__
 -  `UnitTestFrameworkPkg/Library/CmockaLib/cmocka <https://github.com/tianocore/edk2-cmocka/blob/f5e2cd77c88d9f792562888d2b70c5a396bfbf7a/COPYING>`__
 -  `UnitTestFrameworkPkg/Library/GoogleTestLib/googletest <https://github.com/google/googletest/blob/86add13493e5c881d7e4ba77fb91c1f57752b3a4/LICENSE>`__
--  `UnitTestFrameworkPkg/Library/SubhookLib/subhook <https://github.com/Zeex/subhook/blob/83d4e1ebef3588fae48b69a7352cc21801cb70bc/LICENSE.txt>`__
+-  `UnitTestFrameworkPkg/Library/SubhookLib/subhook <https://github.com/tianocore/edk2-subhook/blob/83d4e1ebef3588fae48b69a7352cc21801cb70bc/LICENSE.txt>`__
 -  `RedfishPkg/Library/JsonLib/jansson <https://github.com/akheron/jansson/blob/2882ead5bb90cf12a01b07b2c2361e24960fae02/LICENSE>`__
 -  `MdePkg/Library/BaseFdtLib/libfdt <https://github.com/devicetree-org/pylibfdt/blob/f39368a217496d32c4091a2dba4045b60649e3a5/BSD-2-Clause>`__
 -  `MdePkg/Library/MipiSysTLib/mipisyst <https://github.com/MIPI-Alliance/public-mipi-sys-t/blob/aae857d0d05ac65152ed24992a4acd834a0a107c/LICENSE>`__

--- a/UnitTestFrameworkPkg/ReadMe.md
+++ b/UnitTestFrameworkPkg/ReadMe.md
@@ -485,8 +485,8 @@ function to be compiled into the test application and then hooked to during a
 test.
 
 This library is mainly a wrapper around the
-[subhook](https://github.com/Zeex/subhook) header and source files. It is
-important to note that the use of the mock function macros and the creation
+[subhook](https://github.com/tianocore/edk2-subhook) header and source files. It
+is important to note that the use of the mock function macros and the creation
 of mock functions requires no knowledge about the SubhookLib. The SubhookLib
 library is entirely hidden and encapsulated within FunctionMockLib, and it
 is only mentioned here to provide a complete explanation on all the libraries


### PR DESCRIPTION
Cherry-pick from https://github.com/tianocore/edk2/pull/6402.

The subhook submodule is no longer available and causes build failures when building coreboot images with EDK II (though not coreboot specific). This fix needs to be back ported to every branch that uses this submodule. :/