### PR TITLE
UefiPayloadPkg: SmmStoreLib: Support 64-bit MMIO store

### DIFF
--- a/UefiPayloadPkg/Include/Coreboot.h
+++ b/UefiPayloadPkg/Include/Coreboot.h
@@ -260,7 +260,9 @@ struct cb_smmstorev2 {
   UINT32    com_buffer_size; /* Size of the communication buffer in byte */
   UINT8     apm_cmd;         /* The command byte to write to the APM I/O port */
   UINT8     unused[3];       /* Set to zero */
-};
+  UINT64    mmap_addr_ext;   /* 64-bit MMIO address of the store for read only access.
+                              * Only available when size field >= 40. */
+} __attribute__ ((packed));
 
 #define CB_TAG_CFR_ROOT  0x0047
 struct cb_cfr {

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -742,13 +742,20 @@ ParseSmmStoreInfo (
   DEBUG ((DEBUG_INFO, "number of blocks: 0x%x\n", CbSSRec->num_blocks));
   DEBUG ((DEBUG_INFO, "communication buffer: 0x%x\n", CbSSRec->com_buffer));
   DEBUG ((DEBUG_INFO, "communication buffer size: 0x%x\n", CbSSRec->com_buffer_size));
-  DEBUG ((DEBUG_INFO, "MMIO address of store: 0x%x\n", CbSSRec->mmap_addr));
 
   SmmStoreInfo->ComBuffer     = CbSSRec->com_buffer;
   SmmStoreInfo->ComBufferSize = CbSSRec->com_buffer_size;
   SmmStoreInfo->BlockSize     = CbSSRec->block_size;
   SmmStoreInfo->NumBlocks     = CbSSRec->num_blocks;
-  SmmStoreInfo->MmioAddress   = CbSSRec->mmap_addr;
+
+  if (CbSSRec->size >= 40 && CbSSRec->mmap_addr_ext) {
+    SmmStoreInfo->MmioAddress   = CbSSRec->mmap_addr_ext;
+  } else {
+    SmmStoreInfo->MmioAddress   = CbSSRec->mmap_addr;
+  }
+
+  DEBUG ((DEBUG_INFO, "MMIO address of store: 0x%llx\n", SmmStoreInfo->MmioAddress));
+
   SmmStoreInfo->ApmCmd        = CbSSRec->apm_cmd;
 
   return RETURN_SUCCESS;

--- a/UefiPayloadPkg/Library/SmmStoreLib/SmmStore.c
+++ b/UefiPayloadPkg/Library/SmmStoreLib/SmmStore.c
@@ -412,7 +412,7 @@ SmmStoreLibInitialize (
   // Mark the memory mapped store as MMIO memory
   //
   Status = gDS->GetMemorySpaceDescriptor (mSmmStoreInfo->MmioAddress, &GcdDescriptor);
-  if (EFI_ERROR (Status) || (GcdDescriptor.GcdMemoryType != EfiGcdMemoryTypeMemoryMappedIo)) {
+  if (EFI_ERROR (Status)) {
     DEBUG (
       (
        DEBUG_INFO,
@@ -431,17 +431,17 @@ SmmStoreLibInitialize (
                     EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
                     );
     ASSERT_EFI_ERROR (Status);
+  } else {
+    //
+    // Mark as runtime service
+    //
+    Status = gDS->SetMemorySpaceAttributes (
+      mSmmStoreInfo->MmioAddress,
+      mSmmStoreInfo->NumBlocks * mSmmStoreInfo->BlockSize,
+      GcdDescriptor.Attributes | EFI_MEMORY_RUNTIME
+      );
+    ASSERT_EFI_ERROR (Status);
   }
-
-  //
-  // Mark as runtime service
-  //
-  Status = gDS->SetMemorySpaceAttributes (
-                  mSmmStoreInfo->MmioAddress,
-                  mSmmStoreInfo->NumBlocks * mSmmStoreInfo->BlockSize,
-                  EFI_MEMORY_RUNTIME
-                  );
-  ASSERT_EFI_ERROR (Status);
 
   return EFI_SUCCESS;
 }

--- a/UefiPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntime.c
+++ b/UefiPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntime.c
@@ -172,7 +172,7 @@ SmmStoreInitialize (
   EFI_PHYSICAL_ADDRESS  MmioAddress;
   UINTN                 BlockSize;
   UINTN                 BlockCount;
-  UINT32                NvStorageBase;
+  UINT64                NvStorageBase;
   UINT32                NvStorageSize;
   UINT32                NvVariableSize;
   UINT32                FtwWorkingSize;
@@ -211,7 +211,7 @@ SmmStoreInitialize (
   FtwSpareSize   = (BlockCount / 2) * BlockSize;
   FtwWorkingSize = BlockSize;
   NvVariableSize = NvStorageSize - FtwSpareSize - FtwWorkingSize;
-  DEBUG ((DEBUG_INFO, "NvStorageBase:0x%x, NvStorageSize:0x%x\n", NvStorageBase, NvStorageSize));
+  DEBUG ((DEBUG_INFO, "NvStorageBase:0x%llx, NvStorageSize:0x%x\n", NvStorageBase, NvStorageSize));
 
   if (NvVariableSize >= 0x80000000) {
     SmmStoreLibDeinitialize ();
@@ -220,22 +220,28 @@ SmmStoreInitialize (
 
   Status = PcdSet32S (PcdFlashNvStorageVariableSize, NvVariableSize);
   ASSERT_EFI_ERROR (Status);
-  Status = PcdSet32S (PcdFlashNvStorageVariableBase, NvStorageBase);
-  ASSERT_EFI_ERROR (Status);
+  if (NvStorageBase < 0x100000000ULL) {
+    Status = PcdSet32S (PcdFlashNvStorageVariableBase, NvStorageBase);
+    ASSERT_EFI_ERROR (Status);
+  }
   Status = PcdSet64S (PcdFlashNvStorageVariableBase64, NvStorageBase);
   ASSERT_EFI_ERROR (Status);
 
   Status = PcdSet32S (PcdFlashNvStorageFtwWorkingSize, FtwWorkingSize);
   ASSERT_EFI_ERROR (Status);
-  Status = PcdSet32S (PcdFlashNvStorageFtwWorkingBase, NvStorageBase + NvVariableSize);
-  ASSERT_EFI_ERROR (Status);
+  if ((NvStorageBase + NvVariableSize) < 0x100000000ULL) {
+    Status = PcdSet32S (PcdFlashNvStorageFtwWorkingBase, NvStorageBase + NvVariableSize);
+    ASSERT_EFI_ERROR (Status);
+  }
   Status = PcdSet64S (PcdFlashNvStorageFtwWorkingBase64, NvStorageBase + NvVariableSize);
   ASSERT_EFI_ERROR (Status);
 
   Status = PcdSet32S (PcdFlashNvStorageFtwSpareSize, FtwSpareSize);
   ASSERT_EFI_ERROR (Status);
-  Status = PcdSet32S (PcdFlashNvStorageFtwSpareBase, NvStorageBase + NvVariableSize + FtwWorkingSize);
-  ASSERT_EFI_ERROR (Status);
+  if ((NvStorageBase + NvVariableSize + FtwWorkingSize) < 0x100000000ULL) {
+    Status = PcdSet32S (PcdFlashNvStorageFtwSpareBase, NvStorageBase + NvVariableSize + FtwWorkingSize);
+    ASSERT_EFI_ERROR (Status);
+  }
   Status = PcdSet64S (PcdFlashNvStorageFtwSpareBase64, NvStorageBase + NvVariableSize + FtwWorkingSize);
   ASSERT_EFI_ERROR (Status);
 


### PR DESCRIPTION
On AMD platforms the SPI flash might be mapped in high MMIO. To migitate the problem coreboot [1] was updated to advertise a 64-bit MMIO address in the cb_smmstorev2 struct.

Check if the additional field it written by comparing the size field and if so use it over the old 32-bit MMIO address.

1: https://review.coreboot.org/c/coreboot/+/87114

TEST: Boots on AMD/birman+ with ROM3 bar enabled in high MMIO.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

AMD Birman+ with ROM3 BAR in high MMIO above 4GiB.


