### PR TITLE
BaseTools/EfiRom: fix compiler warning

### DIFF
--- a/BaseTools/Source/C/EfiRom/EfiRom.c
+++ b/BaseTools/Source/C/EfiRom/EfiRom.c
@@ -44,7 +44,6 @@ Returns:
   FILE_LIST *FList;
   UINT32    TotalSize;
   UINT32    Size;
-  CHAR8     *Ptr0;
 
   SetUtilityName(UTILITY_NAME);
 
@@ -75,7 +74,7 @@ Returns:
   //
   if (mOptions.DumpOption == 1) {
     if (mOptions.FileList != NULL) {
-      if ((Ptr0 = strstr ((CONST CHAR8 *) mOptions.FileList->FileName, DEFAULT_OUTPUT_EXTENSION)) != NULL) {
+      if (strstr ((CONST CHAR8 *) mOptions.FileList->FileName, DEFAULT_OUTPUT_EXTENSION) != NULL) {
         DumpImage (mOptions.FileList);
         goto BailOut;
       } else {


### PR DESCRIPTION
This is just a cherry-pick of https://github.com/tianocore/edk2/commit/9af06ef3cbb052b142f9660c2c01e7aeb401300c

Fixes building with new GCC (tested with GCC version 15.2.1 20260209).

Quoting original commit message:

> New warning after updating gcc:
> 
> EfiRom.c: In function ‘main’:
> EfiRom.c:78:17: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
> 
> The assigned value is not used, so fix the warning by just removing it.