### PR TITLE
UefiPayloadPkg: Add FMP_DEVICE_PKCS7_PCD_INC define

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -49,6 +49,7 @@
   DEFINE LOCKBOX_SUPPORT              = FALSE
   DEFINE LOAD_OPTION_ROMS             = FALSE
   DEFINE FOLLOW_BGRT_SPEC             = FALSE
+  DEFINE FMP_DEVICE_PKCS7_PCD_INC     = BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
 
   #
   # Capsule updates
@@ -1241,7 +1242,7 @@
       #
       # See BaseTools/Source/Python/Pkcs7Sign/Readme.md for more details on such
       # PCDs and include files.
-      !include BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+      !include $(FMP_DEVICE_PKCS7_PCD_INC)
     <LibraryClasses>
 !if $(BOOTLOADER) == "COREBOOT"
       FmpDeviceLib|UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf


### PR DESCRIPTION
# Description

Recent coreboot trees override this define rather than patching the FMP root certificate file in the repo. To make this work, it must exist.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Before: Observe that the "Using default keys" warning is shown when EDK2 is loading.
- Built coreboot with `CONFIG_DRIVERS_EFI_CAPSULE_TRUSTED_PUBLIC_CERT` set to a non-default certificate.
- After flashing, ensure that the warning is not shown.


## Integration Instructions

N/A
